### PR TITLE
rwa html が展開されなくなったので修正

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -13,3 +13,6 @@ theme = "beautifulHugo"
   github = "gennei"
   twitter = "gennei"
   instagram = "gennei"
+
+[markup.goldmark.renderer]
+  unsafe = true

--- a/content/post/coffee-goods-2017.md
+++ b/content/post/coffee-goods-2017.md
@@ -17,6 +17,7 @@ draft: false
 <a target="_blank" href="https://www.amazon.co.jp/dp/B0019M4H16?tag=gennei-22">
 <img border="0" src="https://ws-fe.amazon-adsystem.com/widgets/q?MarketPlace=JP&ASIN=B0019M4H16&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL160_&tag=gennei-22">
 </a>
+
 [ビアレッティ 直火式 モカエキスプレス 2カップ](https://www.amazon.co.jp/dp/B0019M4H16?tag=gennei-22)
 
 エスプレッソ系の飲み物を自宅で淹れることができないので買ってみた。カフェラテを作ろうと思うとミルクウォーマーが必要なのでカフェオレとして飲むのにちょうどいい。夏にはトニックウォーターで割った `エスプレッソトニック` を作るのにも重宝した。
@@ -24,6 +25,7 @@ draft: false
 ### エアロプレス
 <a target="_blank" href="https://www.amazon.co.jp/dp/B005Z9XZ1W?tag=gennei-22">
 <img border="0" src="//ws-fe.amazon-adsystem.com/widgets/q?_encoding=UTF8&MarketPlace=JP&ASIN=B005Z9XZ1W&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL160_&tag=gennei-22"></a>
+
 [エアロプレス コーヒーメーカー](https://www.amazon.co.jp/dp/B005Z9XZ1W?tag=gennei-22)
 
 気にはなっていたが手を出していなかった器具の1つ。未だに上手に淹れるのができないので、ハンドドリップをしていることが多い。
@@ -31,6 +33,7 @@ draft: false
 ### 水出し
 <a target="_blank" href="https://www.amazon.co.jp/dp/B00I7JKAQ0?tag=gennei-22">
 <img border="0" src="//ws-fe.amazon-adsystem.com/widgets/q?_encoding=UTF8&MarketPlace=JP&ASIN=B00I7JKAQ0&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL160_&tag=gennei-22"></a>
+
 [HARIO 水出し コーヒーポット](https://www.amazon.co.jp/dp/B00I7JKAQ0?tag=gennei-22)
 
 夏になるとアイスコーヒーが飲みたくなるので今年はアイスコーヒーも作ってみた。コーヒー豆を挽いて冷蔵庫で半日放置しておけば飲めるようになる。牛乳を買ってきてアイスミルクコーヒーとして飲んでも美味しかった。
@@ -38,6 +41,7 @@ draft: false
 ### エスプレッソマシン
 <a target="_blank" href="https://www.amazon.co.jp/dp/B0047C8856?tag=gennei-22">
 <img border="0" src="//ws-fe.amazon-adsystem.com/widgets/q?_encoding=UTF8&MarketPlace=JP&ASIN=B0047C8856&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL160_&tag=gennei-22"></a>
+
 [デロンギ エスプレッソマシン EC152J](https://www.amazon.co.jp/dp/B0047C8856?tag=gennei-22)
 
 なんだかんだエスプレッソマシンを触りたい欲求と、カフェラテを作りたい欲求が出てきたので買った。まだまだ上手に淹れることができないがいじれる箇所が多いので楽しめている。
@@ -45,6 +49,7 @@ draft: false
 ### ミルクジャグ
 <a target="_blank" href="https://www.amazon.co.jp/dp/B00ICCX1V8?tag=gennei-22">
 <img border="0" src="//ws-fe.amazon-adsystem.com/widgets/q?_encoding=UTF8&MarketPlace=JP&ASIN=B00ICCX1V8&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL160_&tag=gennei-22"></a>
+
 [ブラック バール ミルクジャグ](https://www.amazon.co.jp/dp/B00ICCX1V8?tag=gennei-22)
 
 ヨドバシカメラで売っていてこれだけ黒色なので気に入って買った。
@@ -52,6 +57,7 @@ draft: false
 ### ショットグラス
 <a target="_blank" href="https://www.amazon.co.jp/dp/B076HNXZVY?tag=gennei-22">
 <img border="0" src="//ws-fe.amazon-adsystem.com/widgets/q?_encoding=UTF8&MarketPlace=JP&ASIN=B076HNXZVY&ServiceVersion=20070822&ID=AsinImage&WS=1&Format=_SL160_&tag=gennei-22"></a>
+
 [アンカーホッキング キッチンショット](https://www.amazon.co.jp/dp/B076HNXZVY?tag=gennei-22)
 
 エスプレッソのショットをいれておくもの。2つほど買ってエスプレッソマシンと合わせて使っている。


### PR DESCRIPTION
## 参考記事
[Hugo v0.60.0 更新後、Markdown に HTML を入れている場合。](https://blog.balloon.im/2019/11/hugo-v0.60.0-%E6%9B%B4%E6%96%B0%E5%BE%8Cmarkdown-%E3%81%AB-html-%E3%82%92%E5%85%A5%E3%82%8C%E3%81%A6%E3%81%84%E3%82%8B%E5%A0%B4%E5%90%88/)

> .md ファイルに HTML を入れている場合、デフォルトでは無視するようになりました。
> .
> .
> .
> この設定は config に入れるものですが、上記は config.yaml の記載方法です。
> 多くのテーマでは config.toml が採用されていますので……
> 
> [markup.goldmark.renderer]
>   unsafe = true
> これを config.toml の末尾に追加しておけば良いです。